### PR TITLE
Adding version number hidden on footer

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,1 @@
+export const version: string = '0.1.0';

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -46,7 +46,7 @@
                 <div class="hj-container">
                     <div class="hj-copyright">
                         Copyright &copy; 2019 Hjonk.net
-                        <div class="hj-version-number">v{{ versionNumber }}</div>
+                        <div class="hj-version-number">v{{ version }}</div>
                     </div>
 
                     <nav>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -46,6 +46,7 @@
                 <div class="hj-container">
                     <div class="hj-copyright">
                         Copyright &copy; 2019 Hjonk.net
+                        <div class="hj-version-number">v{{ versionNumber }}</div>
                     </div>
 
                     <nav>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -81,13 +81,17 @@
         .hj-container {
             padding: 48px 0;
             display: flex;
-            align-items: center;
+            align-items: baseline;
             flex-wrap: wrap;
 
             .hj-copyright {
                 font-size: 12px;
                 opacity: 0.5;
                 flex: 1 1 auto;
+            }
+
+            .hj-version-number {
+                color: #303030;
             }
 
             button {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,9 +7,11 @@ import { version } from '../../config';
     styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-    private versionNumber: string;
+    private readonly versionNumber: string = version;
 
-    public constructor() {
-        this.versionNumber = version;
+    public constructor() {}
+
+    public get version(): string {
+        return this.versionNumber;
     }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { version } from '../../config';
 
 @Component({
     selector: 'hj-app',
@@ -6,4 +7,9 @@ import { Component } from '@angular/core';
     styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
+    private versionNumber: string;
+
+    public constructor() {
+        this.versionNumber = version;
+    }
 }


### PR DESCRIPTION
**Note: Light blue line is just an extension to show that the Copyright text is aligned properly with the right side links.**

<img width="745" alt="Screen Shot 2020-02-15 at 5 59 13 PM" src="https://user-images.githubusercontent.com/17420723/74597007-0ff1cd00-501d-11ea-892b-15e2d190c136.png">

## Added
1. `config.ts` file with exported version number
2. Used above export const in app.component.
3. Matches package.json as well. 
